### PR TITLE
ci: bump Set Project Month workflow to v1.21.0

### DIFF
--- a/.github/workflows/set-project-month.yaml
+++ b/.github/workflows/set-project-month.yaml
@@ -6,5 +6,5 @@ on:
 
 jobs:
   set-month:
-    uses: datum-cloud/actions/.github/workflows/set-project-month.yaml@v1.13.2
+    uses: datum-cloud/actions/.github/workflows/set-project-month.yaml@v1.21.0
     secrets: inherit


### PR DESCRIPTION
## Summary

datum-cloud/actions v1.21.0 switches this workflow from the project Month field to the Iteration field. Bumps the pin here to pick that up.

## Test plan

- [ ] Open or reopen a PR against this repo and confirm the check sets the Iteration field on the project item.