### PR TITLE
fix(macos): Enable template mode for menu bar tray icon

### DIFF
--- a/ui/src/main.rs
+++ b/ui/src/main.rs
@@ -1043,10 +1043,15 @@ fn init_tray() -> std::sync::Arc<TrayState> {
         .expect("Failed to build tray menu");
 
     let menu_for_state = tray_menu.clone();
-    let mut builder = TrayIconBuilder::new()
-        .with_menu(Box::new(tray_menu))
-        .with_tooltip("Datum")
-        .with_icon(tray_icon());
+    let builder = {
+        let builder = TrayIconBuilder::new()
+            .with_menu(Box::new(tray_menu))
+            .with_tooltip("Datum")
+            .with_icon(tray_icon());
+        #[cfg(target_os = "macos")]
+        let builder = builder.with_icon_as_template(true);
+        builder
+    };
     let tray = builder
         .build()
         .std_context("building tray icon")
@@ -1079,7 +1084,7 @@ fn tray_icon() -> Icon {
     icon()
 }
 
-/// macOS menu bar icon (white logo on transparent background).
+/// macOS menu bar icon (monochrome logo on transparent background; tinted by the system).
 #[cfg(all(feature = "desktop", target_os = "macos"))]
 fn tray_icon() -> Icon {
     load_icon_from_bytes(include_bytes!("../assets/tray/tray-icon-template.png"))


### PR DESCRIPTION
## Summary

On macOS, the Datum tray icon stayed white while neighboring menu bar icons switched between light and dark tints. We already ship a monochrome PNG named for template use, but never told AppKit to treat it as one. Without `NSImage.isTemplate`, the system draws the pixels literally instead of adapting them to the menu bar background.

This sets `with_icon_as_template(true)` on the `TrayIconBuilder` for macOS builds. macOS then uses the icon's alpha channel as a mask and picks the right foreground color for light menu bars, dark menu bars, and highlighted states. No second asset or appearance polling required.

## Test plan

- [x] Build and run Datum on macOS
- [x] Light menu bar (light wallpaper): tray icon appears dark like system icons
- [x] Dark menu bar: tray icon appears light
- [x] Click the tray icon: highlight state looks correct
- [x] System Settings → Accessibility → Display → Reduce transparency: icon readable on solid gray menu bar
- [x] Tray context menu and recent tunnel items unchanged